### PR TITLE
Fix link to envato

### DIFF
--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -195,7 +195,7 @@
           <p>Check out who uses Lotus:</p>
           <a href="https://dnsimple.com" target="_blank"><%= image_tag 'dnssimple.png' %></a>
           <a href="https://tatsu.io" target="_blank"><%= image_tag 'tatsu.png' %></a>
-          <a href="https://envato.com" target="_blank"><img src="/images/envato.png" /></a>
+          <a href="http://envato.com" target="_blank"><img src="/images/envato.png" /></a>
         </article>
       </div>
     </section>


### PR DESCRIPTION
Either http://envato.com, or https://www.envato.com works, but not https://envato.com.
